### PR TITLE
Current user endpoint

### DIFF
--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -145,4 +145,25 @@ defmodule Streamr.UserControllerTest do
       assert %{"email_available" => true} == json_response(conn, 200)
     end
   end
+
+  describe "GET /api/v1/users/me" do
+    test "when the user is authenticated" do
+      user = insert(:user)
+      conn = build_conn()
+             |> Guardian.Plug.api_sign_in(user)
+             |> get("/api/v1/users/me")
+
+      body = json_response(conn, 200)["data"]
+
+      assert body["id"] == Integer.to_string(user.id)
+      assert body["attributes"]["email"] == user.email
+      assert body["attributes"]["name"] == user.name
+    end
+
+    test "when there is no authentication" do
+      conn = build_conn() |> get("/api/v1/users/me")
+
+      json_response(conn, 401)
+    end
+  end
 end

--- a/web/controllers/auth_handler.ex
+++ b/web/controllers/auth_handler.ex
@@ -1,0 +1,9 @@
+defmodule Streamr.AuthHandler do
+  use Streamr.Web, :controller
+
+  def unauthenticated(conn, _params) do
+    conn
+    |> put_status(401)
+    |> render(Streamr.AuthView, "unauthenticated.json")
+  end
+end

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -1,5 +1,6 @@
 defmodule Streamr.UserController do
   use Streamr.Web, :controller
+  plug Streamr.Authenticate when action in [:me]
   alias Streamr.{User, RefreshToken, Repo}
 
   def create(conn, %{"user" => user_params}) do
@@ -50,6 +51,10 @@ defmodule Streamr.UserController do
   def email_available(conn, %{"email" => email}) do
     conn
     |> render("email_available.json", email_available: !Repo.get_by(User, email: email))
+  end
+
+  def me(conn, _assigns) do
+    render(conn, "show.json-api", data: Guardian.Plug.current_resource(conn))
   end
 
   defp generate_access_token(conn, user) do

--- a/web/plugs/authenticate.ex
+++ b/web/plugs/authenticate.ex
@@ -1,0 +1,5 @@
+defmodule Streamr.Authenticate do
+  use Plug.Builder
+
+  plug Guardian.Plug.EnsureAuthenticated, handler: Streamr.AuthHandler
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -21,6 +21,7 @@ defmodule Streamr.Router do
     resources "/users", UserController, only: [:create]
     post "/users/auth", UserController, :auth
     get "/users/email_available", UserController, :email_available
+    get "/users/me", UserController, :me
 
     resources "/streams", StreamController, only: [:index]
   end

--- a/web/router.ex
+++ b/web/router.ex
@@ -11,7 +11,7 @@ defmodule Streamr.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
-    plug Guardian.Plug.VerifyHeader
+    plug Guardian.Plug.VerifyHeader, realm: "Bearer"
     plug Guardian.Plug.LoadResource
   end
 

--- a/web/views/auth_view.ex
+++ b/web/views/auth_view.ex
@@ -1,0 +1,10 @@
+defmodule Streamr.AuthView do
+  def render("unauthenticated.json", _assigns) do
+    %{
+      errors: [%{
+        title: "unauthenticated",
+        detail: "Authentication header empty or invalid"
+      }]
+    }
+  end
+end


### PR DESCRIPTION
Adds an endpoint for fetching data about the current user. If there is an auth token header, the user associated with it is serialized. Otherwise, the server responds with a 401.