### PR TITLE
Update .travis.yml to increase build speeds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,8 @@ otp_release:
 script:
   - mix test
   - mix dogma
+
+cache:
+  directories:
+    - _build
+    - deps


### PR DESCRIPTION
Supposedly [this](https://dockyard.com/blog/2015/12/02/speeding-up-elixir-project-build-times-on-travis-ci) refers to caching the `_build` and `deps` but I am kind of worried this will still fail more than we would like just given that we do change things quite often as far as plugs. Thoughts @GregKWhite?