### PR TITLE
Feature/add pagination

### DIFF
--- a/lib/streamr/repo.ex
+++ b/lib/streamr/repo.ex
@@ -1,3 +1,4 @@
 defmodule Streamr.Repo do
   use Ecto.Repo, otp_app: :streamr
+  use Scrivener, page_size: 20
 end

--- a/mix.exs
+++ b/mix.exs
@@ -18,8 +18,22 @@ defmodule Streamr.Mixfile do
   # Type `mix help compile.app` for more information.
   def application do
     [mod: {Streamr, []},
-     applications: [:phoenix, :phoenix_pubsub, :phoenix_html, :cowboy, :logger, :gettext,
-                    :phoenix_ecto, :postgrex, :comeonin, :ja_serializer, :guardian]]
+     applications: [
+         :phoenix,
+         :phoenix_pubsub,
+         :phoenix_html,
+         :cowboy,
+         :logger,
+         :gettext,
+         :phoenix_ecto,
+         :postgrex,
+         :comeonin,
+         :ja_serializer,
+         :guardian,
+         :scrivener_ecto,
+         :scrivener
+       ]
+    ]
   end
 
   # Specifies which paths to compile per environment.
@@ -30,20 +44,24 @@ defmodule Streamr.Mixfile do
   #
   # Type `mix help deps` for examples and options.
   defp deps do
-    [{:phoenix, "~> 1.2.1"},
-     {:phoenix_pubsub, "~> 1.0"},
-     {:phoenix_ecto, "~> 3.0"},
-     {:postgrex, ">= 0.0.0"},
-     {:phoenix_html, "~> 2.6"},
-     {:phoenix_live_reload, "~> 1.0", only: :dev},
-     {:gettext, "~> 0.11"},
-     {:cowboy, "~> 1.0"},
-     {:comeonin, "~> 2.0"},
-     {:ja_serializer, "~> 0.11.1"},
-     {:guardian, "~> 0.13.0"},
-     {:ex_machina, "~> 1.0", only: :test},
-     {:cors_plug, "~> 1.1"},
-     {:dogma, "~> 0.1", only: :dev}]
+    [
+      {:phoenix, "~> 1.2.1"},
+      {:phoenix_pubsub, "~> 1.0"},
+      {:phoenix_ecto, "~> 3.0"},
+      {:postgrex, ">= 0.0.0"},
+      {:phoenix_html, "~> 2.6"},
+      {:phoenix_live_reload, "~> 1.0", only: :dev},
+      {:gettext, "~> 0.11"},
+      {:cowboy, "~> 1.0"},
+      {:comeonin, "~> 2.0"},
+      {:ja_serializer, "~> 0.11.1"},
+      {:guardian, "~> 0.13.0"},
+      {:ex_machina, "~> 1.0", only: :test},
+      {:cors_plug, "~> 1.1"},
+      {:dogma, "~> 0.1", only: :dev},
+      {:scrivener_ecto, "~> 1.0"},
+      {:scrivener, "~> 2.0"}
+   ]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.

--- a/mix.lock
+++ b/mix.lock
@@ -26,4 +26,6 @@
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
   "postgrex": {:hex, :postgrex, "0.12.1", "2f8b46cb3a44dcd42f42938abedbfffe7e103ba4ce810ccbeee8dcf27ca0fb06", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.0-rc.4", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
+  "scrivener": {:hex, :scrivener, "2.2.1", "5a84cdfc042e3c318a03f965d8197b8294676a8fff7c4a29e482a90c467ebf19", [:mix], []},
+  "scrivener_ecto": {:hex, :scrivener_ecto, "1.1.3", "f5615f67964e43e8c9958263939bc365c4783cac652dc282784bbd32bb14723f", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: false]}, {:postgrex, "~> 0.11.0 or ~> 0.12.0 or ~> 0.13.0", [hex: :postgrex, optional: true]}, {:scrivener, "~> 2.0", [hex: :scrivener, optional: false]}]},
   "uuid": {:hex, :uuid, "1.1.5", "96cb36d86ee82f912efea4d50464a5df606bf3f1163d6bdbb302d98474969369", [:mix], []}}

--- a/web/controllers/stream_controller.ex
+++ b/web/controllers/stream_controller.ex
@@ -2,8 +2,11 @@ defmodule Streamr.StreamController do
   use Streamr.Web, :controller
   alias Streamr.{Stream, Repo}
 
-  def index(conn, _params) do
-    streams = Stream |> Repo.all |> Repo.preload(:user)
+  def index(conn, params) do
+    streams = Stream
+    |> Stream.with_users
+    |> Stream.ordered
+    |> Repo.paginate(params)
 
     render(conn, "index.json-api", data: streams)
   end

--- a/web/controllers/topic_controller.ex
+++ b/web/controllers/topic_controller.ex
@@ -2,7 +2,11 @@ defmodule Streamr.TopicController do
   use Streamr.Web, :controller
   alias Streamr.{Topic, Repo}
 
-  def index(conn, _params) do
-    render(conn, "index.json-api", data: Repo.all(Topic))
+  def index(conn, params) do
+    topics = Topic
+    |> Topic.ordered
+    |> Repo.paginate(params)
+
+    render(conn, "index.json-api", data: topics)
   end
 end

--- a/web/models/stream.ex
+++ b/web/models/stream.ex
@@ -1,5 +1,7 @@
 defmodule Streamr.Stream do
   use Streamr.Web, :model
+  import Ecto.Query
+
 
   schema "streams" do
     belongs_to :user, Streamr.User
@@ -8,5 +10,18 @@ defmodule Streamr.Stream do
     field :image, :string
 
     timestamps
+  end
+
+  def with_users(query) do
+    from(
+      stream in query,
+      preload: [:user],
+      select: stream
+    )
+  end
+
+  def ordered(query) do
+    from stream in query,
+    order_by: [asc: stream.id]
   end
 end

--- a/web/models/stream.ex
+++ b/web/models/stream.ex
@@ -13,11 +13,9 @@ defmodule Streamr.Stream do
   end
 
   def with_users(query) do
-    from(
-      stream in query,
-      preload: [:user],
-      select: stream
-    )
+    from stream in query,
+    preload: [:user],
+    select: stream
   end
 
   def ordered(query) do

--- a/web/models/topic.ex
+++ b/web/models/topic.ex
@@ -6,4 +6,9 @@ defmodule Streamr.Topic do
 
     timestamps
   end
+
+  def ordered(query) do
+    from topic in query,
+    order_by: [asc: topic.name]
+  end
 end


### PR DESCRIPTION
This adds the `Scrivener` library and adds pagination to Topics and Streams.

Pagination can be configured by the `page_size` and `page` URL params, which correspond to the number of elements per page and the specific page number, respectively.