### PR TITLE
Add slug attributes for streams and topics

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -60,8 +60,9 @@ defmodule Streamr.Mixfile do
       {:cors_plug, "~> 1.1"},
       {:dogma, "~> 0.1", only: :dev},
       {:scrivener_ecto, "~> 1.0"},
-      {:scrivener, "~> 2.0"}
-   ]
+      {:scrivener, "~> 2.0"},
+      {:slugger, "~> 0.1.0"}
+    ]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.

--- a/mix.lock
+++ b/mix.lock
@@ -28,4 +28,5 @@
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
   "scrivener": {:hex, :scrivener, "2.2.1", "5a84cdfc042e3c318a03f965d8197b8294676a8fff7c4a29e482a90c467ebf19", [:mix], []},
   "scrivener_ecto": {:hex, :scrivener_ecto, "1.1.3", "f5615f67964e43e8c9958263939bc365c4783cac652dc282784bbd32bb14723f", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: false]}, {:postgrex, "~> 0.11.0 or ~> 0.12.0 or ~> 0.13.0", [hex: :postgrex, optional: true]}, {:scrivener, "~> 2.0", [hex: :scrivener, optional: false]}]},
+  "slugger": {:hex, :slugger, "0.1.0", "04a0f2da7e0770d41eb15e166aa2b1f8fcd26a80f43ed96d56b1b1d4bc5075df", [:mix], []},
   "uuid": {:hex, :uuid, "1.1.5", "96cb36d86ee82f912efea4d50464a5df606bf3f1163d6bdbb302d98474969369", [:mix], []}}

--- a/web/views/sluggifier.ex
+++ b/web/views/sluggifier.ex
@@ -1,0 +1,18 @@
+defmodule Streamr.Sluggifier do
+  defmacro __using__(slug_attribute) do
+    quote bind_quoted: [attr: slug_attribute] do
+      attributes [:slug]
+
+      def slug(object, _conn) do
+        [object.id, slug_attribute_for(object)]
+        |> Enum.join("-")
+        |> Slugger.slugify()
+      end
+
+      def slug_attribute_for(object) do
+        object
+        |> Map.get(unquote(attr))
+      end
+    end
+  end
+end

--- a/web/views/stream_view.ex
+++ b/web/views/stream_view.ex
@@ -1,6 +1,7 @@
 defmodule Streamr.StreamView do
   use Streamr.Web, :view
   use JaSerializer.PhoenixView
+  use Streamr.Sluggifier, :title
 
   attributes [:title, :description, :image]
   has_one :user, serializer: Streamr.UserView, include: true

--- a/web/views/topic_view.ex
+++ b/web/views/topic_view.ex
@@ -1,6 +1,7 @@
 defmodule Streamr.TopicView do
   use Streamr.Web, :view
   use JaSerializer.PhoenixView
+  use Streamr.Sluggifier, :name
 
   attributes [:name]
 end


### PR DESCRIPTION
This adds a `Streamr.Sluggifier` mixin that can be used to add a `slug` attribute to any model's serializer. 

This was requested by Steven in order to have more friendly frontend URLs.