### PR TITLE
Add ability to generate slugs without object id

### DIFF
--- a/web/views/sluggifier.ex
+++ b/web/views/sluggifier.ex
@@ -1,17 +1,31 @@
 defmodule Streamr.Sluggifier do
-  defmacro __using__(slug_attribute) do
-    quote bind_quoted: [attr: slug_attribute] do
+  defmacro __using__(opts \\ []) do
+    quote do
       attributes [:slug]
 
       def slug(object, _conn) do
-        [object.id, slug_attribute_for(object)]
-        |> Enum.join("-")
-        |> Slugger.slugify()
+        if include_id? do
+          [object.id, slug_attribute_for(object)]
+          |> Enum.join("-")
+          |> Slugger.slugify
+        else
+          object
+          |> slug_attribute_for
+          |> Slugger.slugify
+        end
       end
 
       def slug_attribute_for(object) do
         object
-        |> Map.get(unquote(attr))
+        |> Map.get(slug_attribute)
+      end
+
+      def slug_attribute do
+        Keyword.get(unquote(opts), :attribute)
+      end
+
+      def include_id? do
+        Keyword.get(unquote(opts), :include_id, true)
       end
     end
   end

--- a/web/views/stream_view.ex
+++ b/web/views/stream_view.ex
@@ -1,7 +1,7 @@
 defmodule Streamr.StreamView do
   use Streamr.Web, :view
   use JaSerializer.PhoenixView
-  use Streamr.Sluggifier, :title
+  use Streamr.Sluggifier, attribute: :title
 
   attributes [:title, :description, :image]
   has_one :user, serializer: Streamr.UserView, include: true

--- a/web/views/topic_view.ex
+++ b/web/views/topic_view.ex
@@ -1,7 +1,7 @@
 defmodule Streamr.TopicView do
   use Streamr.Web, :view
   use JaSerializer.PhoenixView
-  use Streamr.Sluggifier, :name
+  use Streamr.Sluggifier, attribute: :name
 
   attributes [:name]
 end


### PR DESCRIPTION
This will be used in the future when we generate slugs for users - we won't want their slug for their channel name to include the id.

I also read up more on metaprogramming, which let me clean up a lot of the code in the Sluggifier.