### PR TITLE
Fix deprecation warnings after Postgrex upgrade

### DIFF
--- a/test/controllers/color_controller_test.exs
+++ b/test/controllers/color_controller_test.exs
@@ -3,8 +3,6 @@ defmodule Streamr.ColorControllerTest do
 
   import Streamr.Factory
 
-  alias Streamr.{Repo, Color}
-
   describe "GET /api/v1/colors" do
     setup do
       insert_list(2, :color)

--- a/web/models/refresh_token.ex
+++ b/web/models/refresh_token.ex
@@ -38,7 +38,8 @@ defmodule Streamr.RefreshToken do
     params = %{user_id: user.id, token: Streamr.SecureRandom.base64(256)}
 
     %RefreshToken{}
-    |> cast(params, ~w(token user_id), [])
+    |> cast(params, [:token, :user_id])
+    |> validate_required([:token, :user_id])
   end
 
   defp remove_oldeset_token(user) do

--- a/web/models/stream.ex
+++ b/web/models/stream.ex
@@ -15,7 +15,8 @@ defmodule Streamr.Stream do
 
   def changeset(model, params \\ :empty) do
     model
-    |> cast(params, ~w(title), ~w(description))
+    |> cast(params, [:title, :description])
+    |> validate_required([:title])
   end
 
   def with_users(query) do

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -13,7 +13,8 @@ defmodule Streamr.User do
 
   def changeset(model, params \\ :empty) do
     model
-    |> cast(params, ~w(name email), [])
+    |> cast(params, [:name, :email])
+    |> validate_required([:name, :email])
     |> validate_length(:email, min: 1, max: 254)
     |> validate_email_uniqueness
   end
@@ -21,7 +22,8 @@ defmodule Streamr.User do
   def registration_changeset(model, params) do
     model
     |> changeset(params)
-    |> cast(params, ~w(password), [])
+    |> cast(params, [:password])
+    |> validate_required([:password])
     |> validate_length(:password, min: 6)
     |> put_pass_hash()
   end


### PR DESCRIPTION
Instead of using `cast/4`, they advocate `cast/3` used with `validate_required`, so I made those changes. I also removed an unused alias in `ColorControllerTest`.