### PR TITLE
Add endpoint for publishing streams

### DIFF
--- a/test/controllers/stream_controller_test.exs
+++ b/test/controllers/stream_controller_test.exs
@@ -6,21 +6,15 @@ defmodule Streamr.StreamControllerTest do
   alias Streamr.{Repo, Stream, StreamData}
 
   describe "GET /api/v1/streams" do
-    setup do
-      insert_list(2, :stream)
-
-      :ok
-    end
-
     test "it returns all streams" do
-      conn = get(
-        build_conn(),
-        "/api/v1/streams"
-      )
+      published_streams = insert_list(3, :stream)
+      _unpublished_streams = insert_list(3, :stream, published_at: nil)
 
-      response = json_response(conn, 200)["data"]
+      conn = get(build_conn(), "/api/v1/streams")
 
-      assert 2 == Enum.count(response)
+      response_ids = conn |> json_response(200) |> ids_from_response()
+
+      assert response_ids == ids_from_db(published_streams)
     end
   end
 

--- a/test/controllers/stream_controller_test.exs
+++ b/test/controllers/stream_controller_test.exs
@@ -12,9 +12,9 @@ defmodule Streamr.StreamControllerTest do
 
       conn = get(build_conn(), "/api/v1/streams")
 
-      response_ids = conn |> json_response(200) |> ids_from_response()
+      response_ids = conn |> json_response(200) |> response_ids()
 
-      assert response_ids == ids_from_db(published_streams)
+      assert response_ids == model_ids(published_streams)
     end
   end
 
@@ -176,7 +176,7 @@ defmodule Streamr.StreamControllerTest do
       post_authorized(stream.user, "/api/v1/streams/#{stream.id}/publish")
       conn = get(build_conn(), "/api/v1/streams")
 
-      response_ids = conn |> json_response(200) |> ids_from_response()
+      response_ids = conn |> json_response(200) |> response_ids()
 
       assert Enum.member?(response_ids, stream.id)
     end

--- a/test/controllers/stream_controller_test.exs
+++ b/test/controllers/stream_controller_test.exs
@@ -166,6 +166,45 @@ defmodule Streamr.StreamControllerTest do
     end
   end
 
+  describe "POST /api/v1/streams/:id/publish" do
+    test "it sets the stream's published_at to the current time" do
+      stream = insert(:stream)
+
+      conn = post_authorized(stream.user, "/api/v1/streams/#{stream.id}/publish")
+      response = json_response(conn, 200)["data"]
+
+      assert response["attributes"]["published-at"]
+    end
+
+    test "it allows the stream to show up in the stream index endpoint" do
+      stream = insert(:stream)
+
+      post_authorized(stream.user, "/api/v1/streams/#{stream.id}/publish")
+      conn = get(build_conn(), "/api/v1/streams")
+
+      response_ids = conn |> json_response(200) |> ids_from_response()
+
+      assert Enum.member?(response_ids, stream.id)
+    end
+
+    test "it prevents publishing another user's streams" do
+      stream = insert(:stream)
+
+      try do
+        post_authorized(insert(:user), "/api/v1/streams/#{stream.id}/publish")
+      rescue
+        exception in Bodyguard.NotAuthorizedError ->
+          assert Plug.Exception.status(exception) == 403
+      end
+    end
+
+    test "it requires the user to be signed in" do
+      conn = post(build_conn(), "/api/v1/streams/#{insert(:stream).id}/publish")
+
+      assert conn.status == 401
+    end
+  end
+
   describe "PUT /api/v1/streams/:id" do
     setup do
       stream = insert(:stream)

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -53,6 +53,19 @@ defmodule Streamr.ConnCase do
         |> Guardian.Plug.api_sign_in(user)
         |> get(endpoint, body)
       end
+
+      def ids_from_response(response) do
+        response
+        |> Map.get("data")
+        |> Enum.map(fn(object) -> String.to_integer(object["id"]) end)
+        |> Enum.sort()
+      end
+
+      def ids_from_db(db_rows) do
+        db_rows
+        |> Enum.map(fn(object) -> object.id end)
+        |> Enum.sort()
+      end
     end
   end
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -54,14 +54,14 @@ defmodule Streamr.ConnCase do
         |> get(endpoint, body)
       end
 
-      def ids_from_response(response) do
+      def response_ids(response) do
         response
         |> Map.get("data")
         |> Enum.map(fn(object) -> String.to_integer(object["id"]) end)
         |> Enum.sort()
       end
 
-      def ids_from_db(db_rows) do
+      def model_ids(db_rows) do
         db_rows
         |> Enum.map(fn(object) -> object.id end)
         |> Enum.sort()

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -26,7 +26,8 @@ defmodule Streamr.Factory do
       title: sequence(:title, &"title-#{&1}"),
       description: sequence(:description, &"description-#{&1}"),
       topic: build(:topic),
-      audio_s3_key: nil
+      audio_s3_key: nil,
+      published_at: Timex.now()
     }
   end
 

--- a/web/controllers/stream_controller.ex
+++ b/web/controllers/stream_controller.ex
@@ -7,6 +7,7 @@ defmodule Streamr.StreamController do
   def index(conn, params) do
     streams = params
               |> filtered_streams()
+              |> Stream.published()
               |> Stream.with_associations()
               |> Stream.ordered()
               |> Repo.paginate(params)
@@ -17,6 +18,7 @@ defmodule Streamr.StreamController do
   def subscribed(conn, params) do
     streams = conn.assigns[:current_user]
               |> Stream.subscribed()
+              |> Stream.published()
               |> Stream.with_associations()
               |> Stream.ordered()
               |> Repo.paginate(params)

--- a/web/models/stream.ex
+++ b/web/models/stream.ex
@@ -24,6 +24,11 @@ defmodule Streamr.Stream do
     timestamps()
   end
 
+  def published(query) do
+    from stream in query,
+    where: not is_nil(stream.published_at)
+  end
+
   def changeset(stream, params \\ %{}) do
     stream
     |> cast(params, [:title, :description, :audio_s3_key])

--- a/web/models/stream.ex
+++ b/web/models/stream.ex
@@ -32,11 +32,15 @@ defmodule Streamr.Stream do
   end
 
   def duration_changeset(model) do
-    published_at = Timex.now()
-    duration = Timex.to_unix(published_at) - Timex.to_unix(model.inserted_at)
+    duration = Timex.to_unix(Timex.now()) - Timex.to_unix(model.inserted_at)
 
     model
-    |> cast(%{duration: duration, published_at: published_at}, [:duration, :published_at])
+    |> cast(%{duration: duration}, [:duration])
+  end
+
+  def publish_changeset(stream) do
+    stream
+    |> cast(%{published_at: Timex.now()}, [:published_at])
   end
 
   def with_associations(query) do

--- a/web/policies/stream_policy.ex
+++ b/web/policies/stream_policy.ex
@@ -1,6 +1,6 @@
 defmodule Streamr.Stream.Policy do
   def can?(user, action, stream)
-  when action in [:add_line, :update, :delete, :end_stream] do
+  when action in [:add_line, :update, :delete, :end_stream, :publish] do
     user.id == stream.user_id
   end
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -39,6 +39,7 @@ defmodule Streamr.Router do
 
       post "/add_line", StreamController, :add_line
       post "/end", StreamController, :end_stream
+      post "/publish", StreamController, :publish
     end
 
     resources "/comments", CommentController, only: [:delete] do


### PR DESCRIPTION
This marks the time at which a stream is published. It will not be visible in index routes until it has been published.