### PR TITLE
Add alternate color palettes

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -10,7 +10,7 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
-alias Streamr.{Repo, Topic, Stream, Color, StreamData}
+alias Streamr.{Repo, Topic, Stream, Color, StreamData, Comment, Vote}
 
 defmodule SeedHelpers do
   def aws_url(path) do
@@ -36,88 +36,48 @@ Repo.insert! %Topic{name: "Physics"}
 Repo.insert! %Topic{name: "US History"}
 Repo.insert! %Topic{name: "World History"}
 
+Repo.delete_all Vote
+Repo.delete_all Comment
 Repo.delete_all StreamData
 Repo.delete_all Stream
-Repo.insert! %Stream{
-  title: "Electic Charge, Fields, and Potential pt. 1",
-  image: SeedHelpers.aws_url("Screen+Shot+2017-01-29+at+6.25.36+PM.png"),
-  user_id: 1
+
+normal_colors = %{
+  red: "#e06c75",
+  blue: "#61afef",
+  green: "#98c379",
+  orange: "#d19a66",
+  purple: "#c678dd",
+  white: "#abb2bf",
 }
 
-Repo.insert! %Stream{
-  title: "Electic Charge, Fields, and Potential pt. 2",
-  image: SeedHelpers.aws_url("Screen+Shot+2017-01-29+at+6.26.01+PM.png"),
-  user_id: 1
+protanopia_colors = %{
+  red: "#7c08ff",
+  blue: "#61afef",
+  green: "#9b9fa2",
+  orange: "#d19a66",
+  purple: "#b940dd",
+  white: "#ffffff",
 }
 
-Repo.insert! %Stream{
-  title: "Half Life Into",
-  image: SeedHelpers.aws_url("Screen+Shot+2017-01-29+at+6.27.00+PM.png"),
-  user_id: 1
-}
+deuteranopia_colors = %{}
 
-Repo.insert! %Stream{
-  title: "Linear Equations",
-  image: SeedHelpers.aws_url("Screen+Shot+2017-01-29+at+6.29.31+PM.png"),
-  user_id: 1
-}
+tritanopia_colors = %{}
 
-Repo.insert! %Stream{
-  title: "Riemann Sum Proof",
-  image: SeedHelpers.aws_url("Screen+Shot+2017-01-29+at+6.30.04+PM.png"),
-  user_id: 1
-}
+color_orders = [
+  {:white, 1},
+  {:red, 2},
+  {:orange, 3},
+  {:green, 4},
+  {:blue, 5},
+  {:purple, 6}
+]
 
-Repo.insert! %Stream{
-  title: "Squeeze Theorem Explained",
-  image: SeedHelpers.aws_url("Screen+Shot+2017-01-29+at+6.34.46+PM.png"),
-  user_id: 1
-}
-
-Repo.insert! %Stream{
-  title: "Intro to Differential Equations",
-  image: SeedHelpers.aws_url("Screen+Shot+2017-01-29+at+6.36.42+PM.png"),
-  user_id: 1
-}
-
-Repo.insert! %Stream{
-  title: "R-squared Coefficient",
-  image: SeedHelpers.aws_url("Screen+Shot+2017-01-29+at+6.38.11+PM.png"),
-  user_id: 1
-}
-
-# Blue
-Repo.insert! %Color{
-  normal: "#61afef",
-  order: 5
-}
-
-# Red
-Repo.insert! %Color{
-  normal: "#e06c75",
-  order: 2
-}
-
-# Green
-Repo.insert! %Color{
-  normal: "#98c379",
-  order: 4
-}
-
-# Purps
-Repo.insert! %Color{
-  normal: "#c678dd",
-  order: 6
-}
-
-# Orange
-Repo.insert! %Color{
-  normal: "#d19a66",
-  order: 3
-}
-
-# White
-Repo.insert! %Color{
-  normal: "#abb2bf",
-  order: 1
-}
+Enum.each color_orders, fn {color, order} ->
+  Repo.insert! %Color{
+    normal: normal_colors[color],
+    protanopia: protanopia_colors[color],
+    deuteranopia: deuteranopia_colors[color],
+    tritanopia: tritanopia_colors[color],
+    order: order
+  }
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -11,13 +11,6 @@
 # and so on) as they will fail if something goes wrong.
 
 alias Streamr.{Repo, Topic, Stream, Color, StreamData, Comment, Vote}
-import IEx;
-
-defmodule SeedHelpers do
-  def aws_url(path) do
-    "https://s3-us-west-2.amazonaws.com/streamr-staging/Seeds/" <> path
-  end
-end
 
 Repo.delete_all Topic
 Repo.insert! %Topic{name: "Art History"}
@@ -36,11 +29,6 @@ Repo.insert! %Topic{name: "Organic Chemistry"}
 Repo.insert! %Topic{name: "Physics"}
 Repo.insert! %Topic{name: "US History"}
 Repo.insert! %Topic{name: "World History"}
-
-# Repo.delete_all Vote
-# Repo.delete_all Comment
-# Repo.delete_all StreamData
-# Repo.delete_all Stream
 
 normal_colors = %{
   white: "#abb2bf",
@@ -97,8 +85,6 @@ Enum.each color_orders, fn {color_atom, order} ->
   }
 
   if color = Repo.get_by(Color, order: order) do
-    if order == 2, do: IEx.pry
-
     color
     |> Color.changeset(changes)
     |> Repo.update!()

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -11,6 +11,7 @@
 # and so on) as they will fail if something goes wrong.
 
 alias Streamr.{Repo, Topic, Stream, Color, StreamData, Comment, Vote}
+import IEx;
 
 defmodule SeedHelpers do
   def aws_url(path) do
@@ -36,31 +37,38 @@ Repo.insert! %Topic{name: "Physics"}
 Repo.insert! %Topic{name: "US History"}
 Repo.insert! %Topic{name: "World History"}
 
-Repo.delete_all Vote
-Repo.delete_all Comment
-Repo.delete_all StreamData
-Repo.delete_all Stream
+# Repo.delete_all Vote
+# Repo.delete_all Comment
+# Repo.delete_all StreamData
+# Repo.delete_all Stream
 
 normal_colors = %{
-  red: "#e06c75",
-  blue: "#61afef",
-  green: "#98c379",
-  orange: "#d19a66",
-  purple: "#c678dd",
   white: "#abb2bf",
+  red: "#e06c75",
+  orange: "#d19a66",
+  green: "#98c379",
+  blue: "#61afef",
+  purple: "#c678dd",
+}
+
+deuteranopia_colors = %{
+  white: "#ffffff",
+  # red: "#9c4bf9",
+  red: "#adedbd",
+  orange: "#d19a66",
+  green: "#9b9fa2",
+  blue: "#61afef",
+  purple: "#b940dd",
 }
 
 protanopia_colors = %{
-  # red: "#7c08ff",
-  red: "#9c4bf9",
-  blue: "#61afef",
-  green: "#9b9fa2",
-  orange: "#d19a66",
-  purple: "#b940dd",
   white: "#ffffff",
+  red: "#9c4bf9",
+  orange: "#d19a66",
+  green: "#9b9fa2",
+  blue: "#61afef",
+  purple: "#b940dd",
 }
-
-deuteranopia_colors = %{}
 
 tritanopia_colors = %{}
 
@@ -73,18 +81,24 @@ color_orders = [
   {:purple, 6}
 ]
 
-Enum.each color_orders, fn {color, order} ->
+Enum.each color_orders, fn {color_atom, order} ->
   changes = %{
-    normal: normal_colors[color],
-    protanopia: protanopia_colors[color],
-    deuteranopia: deuteranopia_colors[color],
-    tritanopia: tritanopia_colors[color],
+    normal: normal_colors[color_atom],
+    protanopia: protanopia_colors[color_atom],
+    deuteranopia: deuteranopia_colors[color_atom],
+    tritanopia: tritanopia_colors[color_atom],
     order: order
   }
 
-  Color
-  |> Repo.get_by(order: order)
-  |> Kernel.||(%Color{})
-  |> Color.changeset(changes)
-  |> Repo.insert_or_update()
+  if color = Repo.get_by(Color, order: order) do
+    if order == 2, do: IEx.pry
+
+    color
+    |> Color.changeset(changes)
+    |> Repo.update!()
+  else
+    %Color{}
+    |> Color.changeset(changes)
+    |> Repo.insert!()
+  end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -53,7 +53,6 @@ normal_colors = %{
 
 deuteranopia_colors = %{
   white: "#ffffff",
-  # red: "#9c4bf9",
   red: "#adedbd",
   orange: "#d19a66",
   green: "#9b9fa2",
@@ -63,14 +62,21 @@ deuteranopia_colors = %{
 
 protanopia_colors = %{
   white: "#ffffff",
-  red: "#9c4bf9",
+  red: "#adedbd",
   orange: "#d19a66",
   green: "#9b9fa2",
   blue: "#61afef",
   purple: "#b940dd",
 }
 
-tritanopia_colors = %{}
+tritanopia_colors = %{
+  white: "#ffffff",
+  red: "#adedbd",
+  orange: "#d19a66",
+  green: "#9b9fa2",
+  blue: "#61afef",
+  purple: "#c500ff",
+}
 
 color_orders = [
   {:white, 1},

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -51,7 +51,8 @@ normal_colors = %{
 }
 
 protanopia_colors = %{
-  red: "#7c08ff",
+  # red: "#7c08ff",
+  red: "#9c4bf9",
   blue: "#61afef",
   green: "#9b9fa2",
   orange: "#d19a66",
@@ -73,11 +74,17 @@ color_orders = [
 ]
 
 Enum.each color_orders, fn {color, order} ->
-  Repo.insert! %Color{
+  changes = %{
     normal: normal_colors[color],
     protanopia: protanopia_colors[color],
     deuteranopia: deuteranopia_colors[color],
     tritanopia: tritanopia_colors[color],
     order: order
   }
+
+  Color
+  |> Repo.get_by(order: order)
+  |> Kernel.||(%Color{})
+  |> Color.changeset(changes)
+  |> Repo.insert_or_update()
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -10,7 +10,7 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
-alias Streamr.{Repo, Topic, Stream, Color, StreamData, Comment, Vote}
+alias Streamr.{Repo, Topic, Color}
 
 Repo.delete_all Topic
 Repo.insert! %Topic{name: "Art History"}

--- a/web/models/color.ex
+++ b/web/models/color.ex
@@ -15,4 +15,8 @@ defmodule Streamr.Color do
     from color in query,
     order_by: [asc: color.order]
   end
+
+  def changeset(color, params \\ []) do
+    cast(color, params, [:normal, :deuteranopia, :protanopia, :tritanopia, :order])
+  end
 end


### PR DESCRIPTION
This adds optional color palettes for the three major color blindness types. Interestingly, the one I found that works for deuteranopia also happened to work for protanopia and tritanopia. 

You can use Sim Daltonism (https://michelf.ca/projects/sim-daltonism/) to check it out.

I also removed the default stream seeds since they weren't necessary. Colors are also upserted so that we can change them down the road without breaking streams.

Here are screenshots for the curious:

## Deuteranopia
<img width="1280" alt="deuteranopia" src="https://cloud.githubusercontent.com/assets/9950212/25028261/08f733d8-2081-11e7-828c-01c1659c8adb.png">

## Protanopia
<img width="1280" alt="protanopia" src="https://cloud.githubusercontent.com/assets/9950212/25028270/17f9d782-2081-11e7-9159-2e9a4e8b562f.png">

## Tritanopia
<img width="1280" alt="tritanopia" src="https://cloud.githubusercontent.com/assets/9950212/25028274/1bb2cdfc-2081-11e7-9f60-ed4b5e65ad81.png">
