### PR TITLE
Add endpoint for trending streams

### DIFF
--- a/test/controllers/stream_controller_test.exs
+++ b/test/controllers/stream_controller_test.exs
@@ -2,6 +2,7 @@ defmodule Streamr.StreamControllerTest do
   use Streamr.ConnCase
 
   import Streamr.Factory
+  import Timex
 
   alias Streamr.{Repo, Stream, StreamData}
 
@@ -70,6 +71,12 @@ defmodule Streamr.StreamControllerTest do
       conn = get(build_conn(), "/api/v1/streams/subscribed")
 
       json_response(conn, 401)
+    end
+  end
+
+  describe "GET /streams/trending" do
+    setup do
+
     end
   end
 
@@ -287,5 +294,9 @@ defmodule Streamr.StreamControllerTest do
           assert Plug.Exception.status(exception) == 403
       end
     end
+  end
+
+  defp days_ago(offset) do
+    Timex.now() |> Timex.shift(days: -1 * offset)
   end
 end

--- a/test/controllers/stream_controller_test.exs
+++ b/test/controllers/stream_controller_test.exs
@@ -75,8 +75,11 @@ defmodule Streamr.StreamControllerTest do
   end
 
   describe "GET /streams/trending" do
-    setup do
-
+    test "it returns streams sorted by a function of their newness and vote count" do
+      _decoys = insert_list(3, :stream)
+      highest_rated = insert(:stream, published_at: days_ago(2))
+      lowest_rated = insert(:stream, published_at: days_ago(10))
+      middle_rated = insert(:stream, published_at: days_ago(5))
     end
   end
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -56,8 +56,7 @@ defmodule Streamr.ConnCase do
 
       def response_ids(response) do
         response
-        |> Map.get("data")
-        |> Enum.map(fn(object) -> String.to_integer(object["id"]) end)
+        |> extract_ids_from_json()
         |> Enum.sort()
       end
 
@@ -65,6 +64,12 @@ defmodule Streamr.ConnCase do
         db_rows
         |> Enum.map(fn(object) -> object.id end)
         |> Enum.sort()
+      end
+
+      def extract_ids_from_json(response) do
+        response
+        |> Map.get("data")
+        |> Enum.map(fn(object) -> String.to_integer(object["id"]) end)
       end
     end
   end

--- a/web/controllers/stream_controller.ex
+++ b/web/controllers/stream_controller.ex
@@ -26,6 +26,16 @@ defmodule Streamr.StreamController do
     render(conn, "index.json-api", data: streams)
   end
 
+  def trending(conn, params) do
+    streams = Stream
+              |> Stream.published()
+              |> Stream.trending()
+              |> Stream.with_associations()
+              |> Repo.paginate(params)
+
+    render(conn, "index.json-api", data: streams)
+  end
+
   def create(conn, %{"stream" => stream_params}) do
     changeset = conn.assigns.current_user
                 |> Ecto.build_assoc(:streams)

--- a/web/models/stream.ex
+++ b/web/models/stream.ex
@@ -49,6 +49,15 @@ defmodule Streamr.Stream do
     order_by: fragment("similarity(?, ?) DESC", stream.title, ^search)
   end
 
+  def trending(query) do
+    from stream in query,
+    order_by: fragment("""
+      (votes_count * log(votes_count + 1) +
+        extract(epoch from published_at))
+      / 45000
+    """)
+  end
+
   def changeset(stream, params \\ %{}) do
     stream
     |> cast(params, [:title, :description, :topic_id, :audio_s3_key, :image_s3_key])

--- a/web/models/stream.ex
+++ b/web/models/stream.ex
@@ -51,10 +51,11 @@ defmodule Streamr.Stream do
 
   def trending(query) do
     from stream in query,
+    where: stream.votes_count > 0,
     order_by: fragment("""
       (votes_count * log(votes_count + 1) +
         extract(epoch from published_at))
-      / 45000
+      / 45000 desc
     """)
   end
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -36,6 +36,7 @@ defmodule Streamr.Router do
     end
 
     get "/streams/subscribed", StreamController, :subscribed
+    get "/streams/trending", StreamController, :trending
     resources "/streams", StreamController do
       resources "/comments", CommentController, only: [:index, :create]
       post "/my_vote", VoteController, :create


### PR DESCRIPTION
It's similar to the reddit algorithm for determining hot topics. We can adjust the algorithm down the road to account for the number of users in the application.