### PR TITLE
Extend auth tokens to 1 week for demo sake

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -37,7 +37,7 @@ config :mime, :types, %{
 
 config :guardian, Guardian,
   issuer: "Streamr",
-  ttl: { 1, :hours },
+  ttl: { 1, :weeks },
   secret_key: %{
     "k" => System.get_env("SECRET_KEY_BASE"),
     "kty" => "oct"


### PR DESCRIPTION
We will revert this later when the frontend starts using refresh tokens.