### PR TITLE
Fix Roboto font path

### DIFF
--- a/web/models/initial_creator.ex
+++ b/web/models/initial_creator.ex
@@ -1,8 +1,6 @@
 defmodule Streamr.InitialCreator do
   alias Streamr.{S3Service, User, Repo}
 
-  @font_path Path.join([System.cwd(), ".imagemagick-assets", "Roboto-Regular.ttf"])
-
   def process(user) do
     filepath = filepath_for(user)
 
@@ -28,7 +26,7 @@ defmodule Streamr.InitialCreator do
         "-size", "1536x1536",
         "canvas:##{background_color}",
         "-fill", text_color(background_color),
-        "-font", @font_path,
+        "-font", font_path(),
         "-pointsize", "200",
         "-gravity", "center",
         "-annotate", "+0+25", initials,
@@ -72,4 +70,8 @@ defmodule Streamr.InitialCreator do
 
   defp limit_names([first_name]), do: [first_name]
   defp limit_names([first_name | other_names]), do: [first_name, List.last(other_names)]
+
+  defp font_path do
+    Path.join([System.cwd(), ".imagemagick-assets", "Roboto-Regular.ttf"])
+  end
 end


### PR DESCRIPTION
Since compilation happens in a different directory on Heroku, I had to move this out of being a compile-time constant, since the path was incorrect.