### PR TITLE
Correctly set content type on S3 uploads

### DIFF
--- a/web/models/stream_uploader.ex
+++ b/web/models/stream_uploader.ex
@@ -32,7 +32,7 @@ defmodule Streamr.StreamUploader do
   end
 
   defp file_name_for(stream) do
-    "uploads/stream_upload_data_#{stream.id}"
+    "uploads/stream_upload_data_#{stream.id}.txt"
   end
 
   defp create_file(name) do

--- a/web/services/s3_service.ex
+++ b/web/services/s3_service.ex
@@ -9,18 +9,18 @@ defmodule Streamr.S3Service do
 
     local_path
     |> Upload.stream_file
-    |> S3.upload(@bucket_name, resource_path)
+    |> S3.upload(@bucket_name, resource_path, content_type: mime_type(local_path))
     |> ExAws.request!
 
     resource_path
   end
 
   defp resource_path_for(model, filepath) do
-    "#{table_name(model)}/#{model.id}/#{hashed_contents(filepath)}#{file_type(filepath)}"
+    "#{table_name(model)}/#{model.id}/#{hashed_contents(filepath)}"
   end
 
-  defp file_type(filepath) do
-    Path.extname(filepath)
+  defp mime_type(filepath) do
+    MIME.from_path(filepath)
   end
 
   defp hashed_contents(filepath) do

--- a/web/services/s3_service.ex
+++ b/web/services/s3_service.ex
@@ -16,7 +16,11 @@ defmodule Streamr.S3Service do
   end
 
   defp resource_path_for(model, filepath) do
-    "#{table_name(model)}/#{model.id}/#{hashed_contents(filepath)}"
+    "#{table_name(model)}/#{model.id}/#{hashed_contents(filepath)}#{file_type(filepath)}"
+  end
+
+  defp file_type(filepath) do
+    Path.extname(filepath)
   end
 
   defp hashed_contents(filepath) do

--- a/web/views/url_qualifier.ex
+++ b/web/views/url_qualifier.ex
@@ -1,5 +1,5 @@
 defmodule Streamr.UrlQualifier do
-  @cdn_url System.get_env("CLOUDFRONT_URL")
+  @cdn_url System.get_env("CDN_URL")
 
   def cdn_url_for(nil), do: nil
   def cdn_url_for(s3_key), do: @cdn_url <> s3_key


### PR DESCRIPTION
This will allow us to actually have Cloudflare gzip our stream data. On average, our files seem to be 4-5x smaller after compression :tada